### PR TITLE
[bug] Variable in decode_config argument was not set line 53 

### DIFF
--- a/scan_list.py
+++ b/scan_list.py
@@ -50,7 +50,7 @@ def mp_worker( BITS, PORT, HTTP,output_list, host ):
                     config["result"] = "Beacon Extraction Failed"
                     output_list.append(config)
             elif data.startswith(b"MZ"):
-                config = decode_config(beacon)
+                config = decode_config(data)
                 if config:
                     print(f"Payload {BITS} bits found")
                     config["port"] = int(PORT)


### PR DESCRIPTION
In the elif condition (if "MZ " in data), I failed and I put "beacon" instead of "data" , for decode_config argument.
"beacon" was not set in this condition (because no need to decode it)